### PR TITLE
Fix fastMNN corrected feature output

### DIFF
--- a/scripts/integration/integration.R
+++ b/scripts/integration/integration.R
@@ -185,7 +185,7 @@ runFastMNN = function(sobj, batch) {
 
 	sce <- fastMNN(expr, batch = sobj@meta.data[[batch]])
 
-	sobj@assays$RNA <- CreateAssayObject(assay(sce, "reconstructed"))
+	sobj@assays$RNA <- CreateAssayObject(as(assay(sce, "reconstructed"), "dgCMatrix")
 	sobj[['X_emb']] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
 
 	return(sobj)


### PR DESCRIPTION
A fastMNN API change causes anndata2ri to break for newer batchelor versions as `LowRankMatrix` can't be converted to python. Converting to `dgCMatrix` fixes that.

Not sure if we want to lock to an older batchelor version or do this fix here.