### PR TITLE
System R libraries remain set when not removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,19 @@ There are multiple different environments for the python dependencies:
 The `scib-pipeline` environment is the one that the user activates before calling the pipeline.
 It needs to be specified under the `py_env` key in the config files under `configs/` so that the pipeline will use it for running python methods. Alternatively, you can specify `scIB-python-paper` as the `py_env` to recreate the environment used in the paper to reproduce the results. 
 
-Furthermore, `scib-pipeline` python environments require the R package [`kBET`](https://github.com/theislab/kBET) to be installed manually. This also requires that environment variables are set as described above, so that R packages are correctly installed and located. Once environment variables have been set, you can install `kBET`:
+Furthermore, `scib-pipeline` python environments require the R package [`kBET`](https://github.com/theislab/kBET) to be installed manually.
+Make sure that the environment variables are set as described above, so that R packages are correctly installed and 
+located by `rpy2`.
+For example, when working with `scib-pipeline`, call
+
+```console
+conda activate scib-pipeline
+conda_prefix=$CONDA_PREFIX
+conda deactivate
+. envs/set_vars.sh $conda_prefix
+```
+
+Once environment variables have been set, you can install `kBET`:
 
 ```commandline
 conda activate <py-environment>
@@ -114,6 +126,15 @@ Rscript -e "devtools::install_github('theislab/kBET')"
 | `envs/scib-R.yml`             | `scib-R`             | Updated environment with R dependencies                                                               |
 
 The R environments require extra R packages to be installed manually.
+Don't forget to set the environment variables before installing anything through R. e.g. for `scib-R`:
+
+```console
+conda activate scib-R
+conda_prefix=$CONDA_PREFIX
+conda deactivate
+. envs/set_vars.sh $conda_prefix
+```
+
 Activate the environment and install the packages all the R dependencies in R directly or use the script `install_R_methods.R`.
 
 ```commandline

--- a/envs/env_vars_activate.sh
+++ b/envs/env_vars_activate.sh
@@ -26,3 +26,8 @@ export QT_QPA_PLATFORM='offscreen'
 R_HOME_OLD=${R_HOME}
 export R_HOME_OLD
 export R_HOME=${CONDA_PREFIX}/lib/R
+
+# unset system R libs
+R_LIBS_OLD=$R_LIBS
+export R_LIBS_OLD
+export R_LIBS=""

--- a/envs/env_vars_deactivate.sh
+++ b/envs/env_vars_deactivate.sh
@@ -21,3 +21,8 @@ unset QT_QPA_PLATFORM_OLD
 R_HOME=${R_HOME_OLD}
 export R_HOME
 unset R_HOME_OLD
+
+# Reset R libs
+R_LIBS=$R_LIBS_OLD
+export $R_LIBS
+unset R_LIBS_OLD


### PR DESCRIPTION
Somehow, the system R libraries remain in `.libPaths()` this unsets the `R_LIBS` env variable so only the conda R_LIBS are used