### PR TITLE
make sure bashrc is sourced when calling shell

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,6 @@
+shell.executable("/bin/bash")
+shell.prefix("source ~/.bashrc; ")
+
 from ScibConfig import *
 
 #configfile: "config.yaml"


### PR DESCRIPTION
On some servers shell calls fail as bashrc is not sourced. The added line (maybe only the 2nd would be enough?) ensure that this is sourced before doing shell calls.