### PR TITLE
Normalise and log test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ and metrics reproducibly for different data scenarios preprocessing setups.
 
 A script in `data/` can be used to generate test data.
 This is useful, in order to ensure that the installation was successful before moving on to a larger dataset.
+The pipeline expects an `anndata` object with normalised and log-transformed counts in `adata.X` and counts in
+`adata.layers['counts']`.
 More information on how to use the data generation script can be found in `data/README.md`.
 
 ### Setup Configuration File

--- a/data/README.md
+++ b/data/README.md
@@ -1,5 +1,6 @@
 # Create Test Data
-In order to test whether the pipeline is running, here is a script that creates a small dataset.
+In order to test whether the pipeline is running, here is a script that creates a small dataset with normalised and
+log-transformed counts.
 
 Call the `generate_data.py` script
 ```

--- a/data/generate_data.py
+++ b/data/generate_data.py
@@ -19,11 +19,12 @@ def get_adata_rand_batch(pca=False, neighbors=False):
     adata.obs['batch'] = np.random.randint(0, n_batch, adata.n_obs)
     # add batch effect to counts
     for i in range(n_batch):
-        adata[adata.obs['batch'] == i].X = adata[adata.obs['batch'] == i].X + i
+        adata[adata.obs['batch'] == i].X += i
     adata.obs['batch'] = adata.obs['batch'].astype(str).astype("category")
 
     adata.layers['counts'] = adata.X
-    sc.pp.recipe_zheng17(adata)
+    sc.pp.normalize_per_cell(adata)
+    sc.pp.log1p(adata)
 
     scib.preprocessing.reduce_data(
         adata,
@@ -83,4 +84,5 @@ if __name__ == '__main__':
 
     if not filepath.exists() or args.force:
         adata = get_adata_rand_batch()
+        print(f'Write anndata to {filepath}')
         adata.write(filepath)

--- a/data/generate_data.py
+++ b/data/generate_data.py
@@ -6,7 +6,7 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
-def get_adata_rand_batch(pca=False, n_top_genes=None, neighbors=False):
+def get_adata_rand_batch(pca=False, neighbors=False):
     """
     Download paul15 dataset and preprocess for data integration pipeline
     """
@@ -19,17 +19,16 @@ def get_adata_rand_batch(pca=False, n_top_genes=None, neighbors=False):
     adata.obs['batch'] = np.random.randint(0, n_batch, adata.n_obs)
     # add batch effect to counts
     for i in range(n_batch):
-        adata[adata.obs.batch == i].X = adata[adata.obs.batch == i].X + i
+        adata[adata.obs['batch'] == i].X = adata[adata.obs['batch'] == i].X + i
     adata.obs['batch'] = adata.obs['batch'].astype(str).astype("category")
 
     adata.layers['counts'] = adata.X
-    sc.pp.filter_cells(adata, min_counts=1)
-    sc.pp.filter_genes(adata, min_counts=1)
+    sc.pp.recipe_zheng17(adata)
 
     scib.preprocessing.reduce_data(
         adata,
         pca=pca,
-        n_top_genes=n_top_genes,
+        n_top_genes=None,
         umap=False,
         neighbors=neighbors
     )

--- a/scripts/integration/Snakefile
+++ b/scripts/integration/Snakefile
@@ -22,7 +22,7 @@ rule integration_run_python:
         cell_type = cfg.get_celltype_option_for_integration,
         hvgs      = cfg.get_hvg,
         timing    = "-t" if cfg.timing else "",
-        cmd       = f"conda run -n {cfg.py_env} python"
+        cmd       = f"conda run --no-capture-output -n {cfg.py_env} python"
     benchmark:
         str(cfg.ROOT / "{scenario}/integration/{scaling}/{hvg}/{method}.h5ad.benchmark")
     shell:
@@ -53,7 +53,7 @@ rule integration_run_r:
     params:
         batch_key = lambda w: cfg.get_from_scenario(w.scenario, key="batch_key"),
         hvgs      = lambda w: cfg.get_hvg(w, rules.integration_prepare.output, prep="RDS"),
-        cmd       = f"conda run -n {cfg.r_env} Rscript",
+        cmd       = f"conda run --no-capture-output -n {cfg.r_env} Rscript",
         timing    = "-t" if cfg.timing else ""
     benchmark:
         str(cfg.ROOT / "{scenario}/integration/{scaling}/{hvg}/R/{method}.RDS.benchmark")
@@ -79,7 +79,7 @@ rule convert_RDS_h5ad:
         Convert integrated data from {wildcards.method} into h5ad
         """
     params:
-        cmd = f"conda run -n {cfg.py_env} python"
+        cmd = f"conda run --no-capture-output -n {cfg.py_env} python"
     shell:
         """
         if [ {wildcards.method} == "conos" ]


### PR DESCRIPTION
Previously, the test data was not normalised and log transformed, as detected in #30.

Here I use `sc.pp.recipe_zheng17` to preprocess the adata, as described in the [tutorial](https://scanpy-tutorials.readthedocs.io/en/latest/paga-paul15.html)