### PR TITLE
Update common.py

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,5 @@
 import pytest
-import scIB
+import scib
 import scanpy as sc
 import numpy as np
 import os


### PR DESCRIPTION
I think you might have forgotten to rewrite the module name to the new one. When I run `python -m unittest discover` in the `.pipeline/` folder, I get:
```bash
EE
======================================================================
ERROR: tests.pipeline.test_metrics (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.pipeline.test_metrics
Traceback (most recent call last):
  File "/apps/gent/RHEL8/haswell-ib/software/Python/3.10.4-GCCcore-11.3.0/lib/python3.10/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/apps/gent/RHEL8/haswell-ib/software/Python/3.10.4-GCCcore-11.3.0/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/kyukon/scratch/gent/vo/001/gvo00117/easybuild/RHEL8/haswell-ib/software/scib-pipeline/20221014-foss-2022a/pipeline/tests/pipeline/test_metrics.py", line 1, in <module>
    from .test_pipeline import *
  File "/kyukon/scratch/gent/vo/001/gvo00117/easybuild/RHEL8/haswell-ib/software/scib-pipeline/20221014-foss-2022a/pipeline/tests/pipeline/test_pipeline.py", line 1, in <module>
    from tests.common import *
  File "/kyukon/scratch/gent/vo/001/gvo00117/easybuild/RHEL8/haswell-ib/software/scib-pipeline/20221014-foss-2022a/pipeline/tests/common.py", line 2, in <module>
    import scIB
ModuleNotFoundError: No module named 'scIB'
```